### PR TITLE
Update main create and mange identity page

### DIFF
--- a/docs/user-guides/create-and-manage-identity/index.md
+++ b/docs/user-guides/create-and-manage-identity/index.md
@@ -12,7 +12,7 @@ vote_sum: 1
 
 `Application Credentials` help you to avoid the practice of embedding user account credentials in configuration files. Instead, the user creates an Application Credential that receives delegated access to a single project and has its own distinct secret. The user can also limit the delegated privileges to a single role in that project. This allows you to adopt the principle of least privilege, where the authenticated service only gains access to the one project and role that it needs to function, rather than all of them.
 
-This approach allows you to consume an API with revealing your user credentials, and lets applications authenticate to Keystone without requiring embedded user credentials.
+This approach allows you to consume an API without revealing your user credentials, and lets applications authenticate to Keystone without requiring embedded user credentials.
 
 Within FlexiHPC you are able to mange `Application Credentials` from the dashboard and/or the CLI.
 


### PR DESCRIPTION
There was a typo regarding the line around user credentials that said "with revealing" which should probably be "without revealing" 

Update the page as this was found by an external user